### PR TITLE
Consistent indentation and JS Lint

### DIFF
--- a/phosphorframework.js
+++ b/phosphorframework.js
@@ -84,7 +84,7 @@
 		};
 		
 		var readBytes = function(byteCount) {
-			var accumulator = 0;
+			var accumulator = 0, i;
 			for(i=0; i < byteCount; i++) {
 				accumulator = (accumulator << 8) + readByte();
 			}
@@ -188,7 +188,7 @@
 		ctx.font = "normal 12px Letter Faces";
 		ctx.fillText(alertText, self._canvas.width/2 - metrics.width/2, self._canvas.height/2);
 		console.log(alertText + " Confirm that your phosphor framework is the same or newer than the composition.  Composition version: " + compVersion + ", framework version: " + self.frameworkVersion);
-	}
+	};
 	
 	var _doFrameBlits = function(blits, clearBeforeBlitting, debugBlits)
 	{

--- a/phosphorframework.js
+++ b/phosphorframework.js
@@ -26,63 +26,63 @@
  *
  */
 
-function PhosphorPlayer(bindto_id){
-    
-	var self = this;
-	this.bindId = bindto_id;
-    this.frameworkVersion = 1;
-    
-	var Base64BitStream = function(inputString) {
-		var _keyStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-		var _bytePosition = 0;
-		var _bitPosition = 0;
-		var _byteArray = [];
-        
-		var setInputString = function(input) {
-			if(!input) return;
-			var byte1, byte2, byte3,
-			enc1, enc2, enc3, enc4,
-			i = 0,
-			j = 0,
-			bytes = (input.length/4) * 3;
-            
-			for (i=0; i<bytes; i+=3) {
-                
+ function PhosphorPlayer(bindto_id){
+ 	
+ 	var self = this;
+ 	this.bindId = bindto_id;
+ 	this.frameworkVersion = 1;
+ 	
+ 	var Base64BitStream = function(inputString) {
+ 		var _keyStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+ 		var _bytePosition = 0;
+ 		var _bitPosition = 0;
+ 		var _byteArray = [];
+ 		
+ 		var setInputString = function(input) {
+ 			if(!input) return;
+ 			var byte1, byte2, byte3,
+ 			enc1, enc2, enc3, enc4,
+ 			i = 0,
+ 			j = 0,
+ 			bytes = (input.length/4) * 3;
+ 			
+ 			for (i=0; i<bytes; i+=3) {
+ 				
 				//get the 3 octects in 4 ascii chars
 				enc1 = _keyStr.indexOf(input.charAt(j++));
 				enc2 = _keyStr.indexOf(input.charAt(j++));
 				enc3 = _keyStr.indexOf(input.charAt(j++));
 				enc4 = _keyStr.indexOf(input.charAt(j++));
-                
+				
 				byte1 = (enc1 << 2) | (enc2 >> 4);
 				byte2 = ((enc2 & 15) << 4) | (enc3 >> 2);
 				byte3 = ((enc3 & 3) << 6) | enc4;
-                
+				
 				_byteArray.push(byte1);
 				_byteArray.push(byte2);
 				_byteArray.push(byte3);
-                
+				
 			}
 		};
-        
+		
 		var _updatePositions = function() {
 			//reset all out bit/byte positions
 			while ( _bitPosition < 0){
 				_bytePosition--;
 				_bitPosition += 8;
 			}
-            
+			
 			while ( _bitPosition > 7){
 				_bytePosition++;
 				_bitPosition -= 8;
 			}
 		};
-        
+		
 		var readByte = function() {
 			var result = readBits(8);
 			return result;
 		};
-        
+		
 		var readBytes = function(byteCount) {
 			var accumulator = 0;
 			for(i=0; i < byteCount; i++) {
@@ -90,67 +90,67 @@ function PhosphorPlayer(bindto_id){
 			}
 			return accumulator;
 		};
-        
+		
 		var readBits = function(bitCount) {
 			var accumulator = 0;
-            
+			
 			if(bitCount > 8) {
 				accumulator += readBits(8) << (bitCount - 8);
 				bitCount -= 8;
 			}
-            
+			
 			if((_bitPosition + bitCount) > 8){
 				var firstBitsLength = 8 - _bitPosition;
 				accumulator += readBits(firstBitsLength) << (bitCount - firstBitsLength);
 				bitCount -= firstBitsLength;
 			}
-            
+			
 			var leftShift = 8 - bitCount - _bitPosition;
 			var bitMask = 0xFF >> (8 - bitCount);
 			bitMask = bitMask << leftShift;
-            
+			
 			var bits = _byteArray[_bytePosition] & bitMask;
-            
+			
 			accumulator += (bits >> leftShift);
-            
+			
 			_bitPosition += bitCount;
-            
+			
 			//reset all out bit/byte positions
 			_updatePositions();
-            
+			
 			return accumulator;
 		};
-        
+		
 		var skipBytes = function(byteCount) {
 			_bytePosition += byteCount;
 		};
-        
+		
 		var skipBits = function(bitCount) {
 			_bitPosition += bitCount;
 			_updatePositions();
 		};
-        
+		
 		var eof = function() {
 			return (_bytePosition >= _byteArray.length);
 		};
-        
+		
 		var bytePos = function() {
 			return _bytePosition;
 		};
-        
+		
 		var jumpToOffsetByteBits = function(byteoffset, bitoffset) {
 			_bytePosition = byteoffset;
 			_bitPosition = bitoffset;
 			_updatePositions();
 		};
-        
+		
 		var byteLength = function() {
 			return _byteArray.length;
 		};
-        
+		
 		//do the class init
 		setInputString(inputString);
-        
+		
 		return {
 			readByte : readByte,
 			readBytes : readBytes,
@@ -159,11 +159,11 @@ function PhosphorPlayer(bindto_id){
 			skipBits : skipBits,
 			eof : eof,
 			bytePos : bytePos,
-        jumpToOffsetByteBits: jumpToOffsetByteBits,
-        byteLength: byteLength
+			jumpToOffsetByteBits: jumpToOffsetByteBits,
+			byteLength: byteLength
 		};
 	};
-    
+	
 	this._debug = false;
 	this._canvas = null;
 	this._imgArray = [];
@@ -176,39 +176,39 @@ function PhosphorPlayer(bindto_id){
 	this._onLoadHandler = "";
 	this._currentFrameCallback = null;
 	this._playbackFinishedCallback = null;
-    
-    
-    var alertFrameworkVersion = function(compVersion) {
-        var ctx = self._canvas.getContext('2d');
+	
+	
+	var alertFrameworkVersion = function(compVersion) {
+		var ctx = self._canvas.getContext('2d');
 		var alertText = "Phosphor Framework Version Mismatch!";
-        var metrics = ctx.measureText(alertText);
-        ctx.fillStyle = "red";
-        ctx.fillRect(self._canvas.width/2 - metrics.width/2 - 5,self._canvas.height/2 - 20,metrics.width+25, 30);
-        ctx.fillStyle = "white";
-        ctx.font = "normal 12px Letter Faces";
-        ctx.fillText(alertText, self._canvas.width/2 - metrics.width/2, self._canvas.height/2);
-        console.log(alertText + " Confirm that your phosphor framework is the same or newer than the composition.  Composition version: " + compVersion + ", framework version: " + self.frameworkVersion);
-    }
-    
+		var metrics = ctx.measureText(alertText);
+		ctx.fillStyle = "red";
+		ctx.fillRect(self._canvas.width/2 - metrics.width/2 - 5,self._canvas.height/2 - 20,metrics.width+25, 30);
+		ctx.fillStyle = "white";
+		ctx.font = "normal 12px Letter Faces";
+		ctx.fillText(alertText, self._canvas.width/2 - metrics.width/2, self._canvas.height/2);
+		console.log(alertText + " Confirm that your phosphor framework is the same or newer than the composition.  Composition version: " + compVersion + ", framework version: " + self.frameworkVersion);
+	}
+	
 	var _doFrameBlits = function(blits, clearBeforeBlitting, debugBlits)
 	{
 		debugBlits = (typeof debugBlits === "undefined") ? false : debugBlits;
 		var ctx = self._canvas.getContext('2d');
 		var isIFrame = false;
-        
+		
 		var bitStream = Base64BitStream(blits);
-        
+		
 		if(bitStream){
-            
+			
 			while((bitStream.byteLength() - bitStream.bytePos()) > 10){
-                
+				
 				//pps
 				bitStream.skipBytes(1); //version
 				var imgindex = bitStream.readByte();
 				var blockSize = bitStream.readBits(5);
 				var frameType = bitStream.readBits(3);
 				var blitArrayByteCount = bitStream.readBytes(2);
-                
+				
 				var srcXYBitDepth = bitStream.readBits(4);
 				var destXBitDepth = bitStream.readBits(4);
 				var destYBitDepth = bitStream.readBits(4);
@@ -216,10 +216,10 @@ function PhosphorPlayer(bindto_id){
 				var srcHeightBitDepth = bitStream.readBits(4);
 				var destWidthBitDepth = bitStream.readBits(4);
 				var destHeightBitDepth = bitStream.readBits(4);
-                
+				
 				bitStream.skipBits(52); //reserved
-                
-                
+				
+				
 				//clear the frame if we are an iframe (much faster than clearing each blit)
 				if(frameType === 0 && !isIFrame){
 					isIFrame = true;
@@ -227,15 +227,15 @@ function PhosphorPlayer(bindto_id){
 					var displayHeight = self._jsonData.framesize.height;
 					ctx.clearRect(0, 0, displayWidth, displayHeight);
 				}
-                
+				
 				var offset = bitStream.bytePos();
-                
+				
 				for(var i = 0; i < blitArrayByteCount; i++)
 				{
-                    
+					
 					var sx = bitStream.readBits(srcXYBitDepth) * blockSize;
 					var sy = bitStream.readBits(srcXYBitDepth) * blockSize;
-                    
+					
 					var w1 = 1 * blockSize;
 					var h1 = 1 * blockSize;
 					if(srcWidthBitDepth > 0){
@@ -244,10 +244,10 @@ function PhosphorPlayer(bindto_id){
 					if(srcHeightBitDepth > 0){
 						h1 = (bitStream.readBits(srcHeightBitDepth) + 1) * blockSize;
 					}
-                    
+					
 					var dx = bitStream.readBits(destXBitDepth) * blockSize;
 					var dy = bitStream.readBits(destYBitDepth) * blockSize;
-                    
+					
 					var w2 = w1;
 					var h2 = h1;
 					if(destWidthBitDepth > 0){
@@ -256,14 +256,14 @@ function PhosphorPlayer(bindto_id){
 					if(destHeightBitDepth > 0){
 						h2 = (bitStream.readBits(destHeightBitDepth) + 1) * blockSize;
 					}
-                    
+					
 					//clear the blit if we are a pframe
 					if(frameType == 1 && clearBeforeBlitting){
 						ctx.clearRect(dx, dy, w2, h2);
 					}
-                    
+					
 					ctx.drawImage(self._imgArray[imgindex], sx, sy, w1, h1, dx, dy, w2, h2);
-                    
+					
 					if(debugBlits){
 						ctx.lineWidth="1";
 						ctx.strokeStyle="red";
@@ -272,30 +272,30 @@ function PhosphorPlayer(bindto_id){
 				}
 			}
 		}
-        
-        
+		
+		
 	};
-    
+	
 	var animate = function()
 	{
-        
+		
 		var metadata = self._jsonData;
 		var dataVersion = metadata.version;
-        
+		
 		var ctx = self._canvas.getContext('2d');
 		if(dataVersion > self.frameworkVersion) {
-            alertFrameworkVersion(dataVersion);
-            return;
-        }
-        
+			alertFrameworkVersion(dataVersion);
+			return;
+		}
+		
 		var clearBeforeBlitting = metadata.hasAlpha;
 		
 		self._timer = setTimeout(function(){f()},0);
-        
+		
 		var f = function()
 		{
 			var frames = metadata.frames;
-            
+			
 			if(self._debug){
 				var lastFrameBlits = frames[self._currentFrameNumber - 1];
 				if(lastFrameBlits){
@@ -305,28 +305,28 @@ function PhosphorPlayer(bindto_id){
 			
 			var blits = frames[self._currentFrameNumber];
 			if(blits){
-            	var frameduration = blits.d;
+				var frameduration = blits.d;
 				_doFrameBlits(blits.x, clearBeforeBlitting, self._debug);
 			}
-            
-            if(self._currentFrameCallback) {
-                if(blits && blits.hasOwnProperty("m")) {
-                    self._currentFrameCallback(self._currentFrameNumber, blits.m);
-                }
-                else {
-                    self._currentFrameCallback(self._currentFrameNumber, null);
-                }
-                
-            }
-            
+			
+			if(self._currentFrameCallback) {
+				if(blits && blits.hasOwnProperty("m")) {
+					self._currentFrameCallback(self._currentFrameNumber, blits.m);
+				}
+				else {
+					self._currentFrameCallback(self._currentFrameNumber, null);
+				}
+				
+			}
+			
 			self._currentFrameNumber++;
-            
+			
 			if(self._currentFrameNumber > frames.length){
-                
+				
 				if(self._playbackFinishedCallback) {
 					self._playbackFinishedCallback();
 				}
-                
+				
 				if(self._loop){
 					self._currentFrameNumber = 0;
 				}else{
@@ -334,41 +334,41 @@ function PhosphorPlayer(bindto_id){
 					return;
 				}
 			}
-            
+			
 			var delay = frameduration * 1000 / metadata.timescale;
 			self._timer = setTimeout(function(){f()},delay);
 			
 		};
 	};
-    
+	
 	var drawCurrentFrame = function()
 	{
 		var metadata = self._jsonData;
 		var dataVersion = metadata.version;
-        
+		
 		var ctx = self._canvas.getContext('2d');
-        
+		
 		if(dataVersion > self.frameworkVersion) {
-            alertFrameworkVersion(dataVersion);
-            return;
-        }
-        
+			alertFrameworkVersion(dataVersion);
+			return;
+		}
+		
 		var clearBeforeBlitting = metadata.hasAlpha;
 		var displayWidth = metadata.framesize.width;
 		var displayHeight = metadata.framesize.height;
-        
+		
 		var frames = metadata.frames;
-        
+		
 		if(clearBeforeBlitting){
 			ctx.clearRect(0, 0, displayWidth, displayHeight);
 		}
-        
+		
 		var blits = frames[self._currentFrameNumber];
 		var frameduration = blits.d;
 		_doFrameBlits(blits.x, clearBeforeBlitting, self._debug);
-        
+		
 	};
-    
+	
 	this.load_animation = function(parameters)
 	{
 		self._atlasImagesLoaded = false;
@@ -379,7 +379,7 @@ function PhosphorPlayer(bindto_id){
 		self._playbackFinishedCallback = parameters.playbackFinishedCallback;
 		self.loadOneImage = function() {
 			if(self.img_urls.length > 0){
-                
+				
 				var img = new Image();
 				img.onload = function() {
 					self._imgArray.push(img);
@@ -393,71 +393,71 @@ function PhosphorPlayer(bindto_id){
 			}
 		};
 		self.loadOneImage();
-        
+		
 		self._jsonData = parameters.animationData;
 		self._frameCount = self._jsonData.frames.length;
-        
+		
 	};
-    
+	
 	this.play = function()
 	{
 		if(self._timer){
 			clearTimeout(self._timer);
 		}
-        
+		
 		if (self._canvas && self._canvas.getContext && self._jsonData && self._atlasImagesLoaded) {
 			animate();
 		}
 		else {
 			setTimeout(function(){ self.play(); }, 100);
 		}
-        
+		
 	};
-    
+	
 	this.stop = function()
 	{
 		if(self._timer){
 			clearTimeout(self._timer);
 		}
 	};
-    
+	
 	this.currentFrameNumber = function()
 	{
 		return self._currentFrameNumber;
 	};
-    
+	
 	this.setCurrentFrameNumber = function(frameNum)
 	{
 		self._currentFrameNumber = frameNum;
 		drawCurrentFrame();
 	};
-    
+	
 	this.debug = function(setdebug)
 	{
 		self._debug = setdebug;
 	};
-    
+	
 	this.loop = function (setLoop) {
 		self._loop = setLoop;
 	};
-    
+	
 	var _bind = function(img_id)
 	{
 		var imgdiv = document.getElementById(img_id);
 		var parent = imgdiv.parentNode;
-        
+		
 		self._canvas = document.createElement('canvas');
-        
-        var canvascheck=(self._canvas.getContext)? true : false
+		
+		var canvascheck=(self._canvas.getContext)? true : false
 		if(!canvascheck) {
 			return false;
 		}
-        
+		
 		self._canvas.id = imgdiv.id;
 		self._canvas.width = imgdiv.width;
 		self._canvas.height = imgdiv.height;
 		self._canvas.style.cssText = 'display:block;';
-        
+		
 		if(imgdiv.complete) {
 			parent.replaceChild(self._canvas,imgdiv);
 			var context = self._canvas.getContext("2d");
@@ -473,7 +473,7 @@ function PhosphorPlayer(bindto_id){
 
 
 	};
-    
+	
 	_bind(bindto_id);
-    
+	
 }


### PR DESCRIPTION
Inconsistent indentation was making this difficult to read in the Github interface and in text editors with different tabstops set.

Most lines were indented with tabs, but some were indented with spaces, I've changed them all to tabs.

`readBytes` was assigning to the global variable i, i.e. it was assigning to an undeclared variable.

`alertFrameworkVersion` was not terminated with a semicolon.
