### PR TITLE
fix bug where Sample does not play

### DIFF
--- a/phosphorframework.js
+++ b/phosphorframework.js
@@ -387,7 +387,7 @@ function PhosphorPlayer(bindto_id){
                     self.loadOneImage();
                 };
 
-                if(self.img_path.length>0) {
+                if(self.img_path && self.img_path.length>0) {
                     img.src = self.img_path + self.img_urls.shift();
                 }
                 else {


### PR DESCRIPTION
The provided Sample/ does not work because it causes the JS to crash due to `img_path` not being defined. 

Added an additional check for the missing parameter
