### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Welcome to Phosphor#
+# Welcome to Phosphor #
 This project contains the Phosphor Framework, which is the javascript toolset used to display compositions created by [Phosphor](http://www.divergentmedia.com/phosphor).  
 
 The framework loads each of the raw image files for the composition, and draws individual 8x8 pixel blocks to the canvas using instructions from a JSON atlas.  Timing (frame duration) is also included in the atlas.
@@ -7,8 +7,8 @@ Additional details on the callbacks available within the framework can be found 
 
 This framework is designed to operate as a standalone library, without any external dependencies on other javascript frameworks (jQuery, etc).
 
-#Contact Us#
+# Contact Us #
 The Phosphor Framework is relatively straightforward, and should be easy to customize by developers looking for functionality not available out of the box. We'd love to see what you build - send us your questions/results at support@divergentmedia.com or fork the framework on GitHub.
 
-#Contributors#
+# Contributors #
 This project uses the [git flow](http://nvie.com/posts/a-successful-git-branching-model/) branching model.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
